### PR TITLE
Use `command` to avoid issues with aliases/functions

### DIFF
--- a/plugin/neoranger.vim
+++ b/plugin/neoranger.vim
@@ -52,7 +52,7 @@ function! s:RangerOpenDir(...)
 	let w:_ranger_del_buf = bufnr('%')
 
 	" Open ranger in nvim terminal
-	call termopen('ranger ' . opts, rangerCallback)
+	call termopen('command ranger ' . opts, rangerCallback)
 	setlocal filetype=ranger
 	startinsert
 endfunction


### PR DESCRIPTION
I use a modified version of this [script](https://github.com/ranger/ranger/wiki/Shell-aliases) as well as a shell function called `ranger` which executes ranger like [here](https://github.com/ranger/ranger/blob/master/examples/bash_automatic_cd.sh).

Using `command` makes sure we use the actual command, unaffected by the user's shell configuration, the other option would be using a full path.

I'm just happy I found what was causing ranger to close immediately, it took me forever to figure out why this wasn't working for me, figured I'd pass it along.

Thanks for the wicked plugin.

Cheers,
Nathaniel