### PR TITLE
throw error instead of plain message if argument is not a path

### DIFF
--- a/plugin/neoranger.vim
+++ b/plugin/neoranger.vim
@@ -2,7 +2,7 @@ function! s:RangerOpenDir(...)
 	let path = a:0 ? a:1 : getcwd()
 
 	if !isdirectory(path)
-		echom 'Not a directory: ' . path
+		echoerr 'Not a directory: ' . path
 		return
 	endif
 


### PR DESCRIPTION
this allows us to catch the error using try catch